### PR TITLE
fix compile error by casting sender to UISwitch

### DIFF
--- a/GemTotSDK/GemTotSDK/Views/GTBeaconTableViewController.swift
+++ b/GemTotSDK/GemTotSDK/Views/GTBeaconTableViewController.swift
@@ -111,7 +111,8 @@ class GTBeaconTableViewController: UITableViewController, UIPickerViewDelegate, 
     // callback funciton called whenever the toggle changes state
     func toggleBeacon(sender :AnyObject!) {
         
-        let state = sender.isOn
+        let button = sender as! UISwitch
+        let state = button.on
         
         if (state == true) {
             let beaconStarted = _beacon.startBeacon()


### PR DESCRIPTION
This appears to fix https://github.com/gemtot/iBeacon/issues/5. The compile error goes away, and the compiled code works locally in XCode and on an iPhone 4S.  Couldn't run tests to verify (there don't appear to be any ?), but I think that manual testing should be sufficient.

Apologies for code quality !  I knew nothing of swift before trying to tackle this and there was a lot of guesswork and googling involved. I wouldn't be at surprised to learn there better solutions.